### PR TITLE
feat: add support for Error Boundary

### DIFF
--- a/src/app/providers/index.ts
+++ b/src/app/providers/index.ts
@@ -1,7 +1,13 @@
 import compose from "compose-function";
 
+import { withErrorBoundary } from "./with-error-boundary";
 import { withGlobalStyle } from "./with-global-style";
 import { withRouter } from "./with-router";
 import { withStore } from "./with-store";
 
-export const withProviders = compose(withStore, withRouter, withGlobalStyle);
+export const withProviders = compose(
+  withStore,
+  withErrorBoundary,
+  withRouter,
+  withGlobalStyle,
+);

--- a/src/app/providers/with-error-boundary.tsx
+++ b/src/app/providers/with-error-boundary.tsx
@@ -1,0 +1,5 @@
+import { ErrorBoundary } from "@/shared/ui";
+
+export const withErrorBoundary = (component: () => React.ReactNode) => () => (
+  <ErrorBoundary>{component()}</ErrorBoundary>
+);

--- a/src/shared/constants/sizing.ts
+++ b/src/shared/constants/sizing.ts
@@ -50,6 +50,7 @@ export const MARGIN_MAP = {
     regular: "16px auto",
     phone: "16px",
   },
+  errorBoundary: "32px auto",
 } as const;
 
 export const RADIUS_MAP = {

--- a/src/shared/ui/ErrorBoundary/ErrorBoundary.styled.ts
+++ b/src/shared/ui/ErrorBoundary/ErrorBoundary.styled.ts
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+import {
+  DISPLAY_MAP,
+  FLEX_PROPERTIES,
+  TEXT_CENTER,
+} from "@/shared/constants/generalStyles";
+import { DIMENSIONS_MAP, GAP_MAP, MARGIN_MAP } from "@/shared/constants/sizing";
+
+export const Wrapper = styled.div`
+  margin: ${MARGIN_MAP.errorBoundary};
+  width: ${DIMENSIONS_MAP.fit};
+  display: ${DISPLAY_MAP.flex};
+  align-items: ${FLEX_PROPERTIES.alignCenter};
+  justify-content: ${FLEX_PROPERTIES.justifyCenter};
+  flex-direction: ${FLEX_PROPERTIES.column};
+  gap: ${GAP_MAP.medium};
+  text-align: ${TEXT_CENTER};
+`;

--- a/src/shared/ui/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/shared/ui/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import { Component } from "react";
+import type { ErrorInfo } from "react";
+
+import { Title, Text } from "@/shared/ui";
+
+import { Wrapper } from "./ErrorBoundary.styled";
+import type { ErrorBoundaryProps, ErrorBoundaryState } from "./interfaces";
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  };
+
+  public static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <Wrapper>
+          <Title text="Error has been encountered!" />
+          <Text
+            text={`Error details: ${this.state.error!.message}`}
+            size="large"
+            isSubtext
+          />
+        </Wrapper>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/shared/ui/ErrorBoundary/interfaces.ts
+++ b/src/shared/ui/ErrorBoundary/interfaces.ts
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+export interface ErrorBoundaryProps {
+  children?: ReactNode;
+}
+
+export interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,6 +1,7 @@
 export { Alert } from "./Alert/Alert";
 export { Avatar } from "./Avatar/Avatar";
 export { Button } from "./Button/Button";
+export { ErrorBoundary } from "./ErrorBoundary/ErrorBoundary";
 export { Header } from "./Header/Header";
 export { IconButton } from "./IconButton/IconButton";
 export { Input } from "./Input/Input";


### PR DESCRIPTION
Добавлен компонент для отлова ошибок. Используется как враппер внутри `withProviders`