### PR TITLE
fix: update tweets fetch error

### DIFF
--- a/src/features/tweets/hooks/useTweets.ts
+++ b/src/features/tweets/hooks/useTweets.ts
@@ -24,7 +24,7 @@ export function useTweets(authorId?: string) {
 
   const fetchTweets = useCallback(async () => {
     const tweetsDBPath = "tweets/";
-    let tweetsData: FirebaseArrayValue<TweetDBInfo> | undefined;
+    let tweetsData: FirebaseDatabaseType<TweetDBInfo[]> | undefined;
     try {
       tweetsData = await getData<TweetDBInfo[]>(tweetsDBPath);
     } catch (error) {
@@ -32,13 +32,15 @@ export function useTweets(authorId?: string) {
       return [];
     }
 
-    const tweetsArray = Object.entries(tweetsData!)
+    const tweetsArray = Object.entries(tweetsData)
       .reverse()
       .map((data) => {
         const [id, value] = data;
+        const { likesIds, ...rest } = value;
         return {
           id,
-          ...value,
+          likesIds: deserializeFirebaseArray(likesIds),
+          ...rest,
         };
       }) satisfies TweetType[];
     dispatch(setTweets(tweetsArray));

--- a/src/shared/types/firebase.ts
+++ b/src/shared/types/firebase.ts
@@ -1,5 +1,5 @@
 export type FirebaseDatabaseType<T> = T extends Array<infer ArrayType>
-  ? FirebaseArrayValue<ArrayType>
+  ? Array<FirebaseDatabaseType<ArrayType>>
   : {
       [K in keyof T]: NonNullable<T[K]> extends Array<infer ArrayType>
         ? FirebaseArrayValue<ArrayType>

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -1,7 +1,6 @@
 declare global {
   declare type RootState = import("../src/app/appStore").RootState;
   declare type AppDispatch = import("../src/app/appStore").AppDispatch;
-  declare type FirebaseExportValue = { [key: string]: unknown };
   declare type FirebaseArrayValue<T> = { [key: string]: T } | undefined;
 }
 


### PR DESCRIPTION
Из-за того, что некоторые твиты хранят в себе `likesIds`, приложение могло падать, потому что данное поле не было десериализовано

Также исправлен тип для метода получения данных с базы данных, чтобы правильно работать, если был передан массив типа